### PR TITLE
Enhance explanation of logarithm in price calculation

### DIFF
--- a/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
+++ b/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
@@ -45,7 +45,7 @@ For this reason, **tick index 887,272 is the highest used by the protocol**, bec
 
 ## The lowest tick index
 
-The lowest tick index is set to -887,272, which is the negative of the highest possible tick.
+The lowest tick index is set to -887,272, which is the negative of the highest possible tick. Mathematically, $i = \log_{1.0001} (2^{-128}) = -\log_{1.0001} (2^{128}) = -887272$. Here we used the logarithm identity $\log_b(x^p) = p \log_b x$.
 
 This symmetry is desirable because the price of token X relative to token Y is the inverse of the price of token Y relative to token X. Thus, it is desirable to limit the minimum token price to $2^{-128}$, which corresponds to tick -887272.
 

--- a/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
+++ b/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
@@ -18,7 +18,7 @@ $$
 p(i)=1.0001^i
 $$
 
-This relationship can be inverted by the definition of logarithm: the logarithm of $x$ to base $b$ is the unique real number $y$ such that $b^y = x$ (reference: [Wikipedia](https://en.wikipedia.org/wiki/Logarithm)). In our case, this translates to the logarithm of $p(i)$ to base $1.0001$ is the unique real number $i$ such that $1.0001^i = p(i)$. In formula this is:
+This relationship can be inverted by the definition of logarithm: the logarithm of $x$ to base $b$ is the unique real number $y$ such that $b^y = x$ (reference: [Wikipedia](https://en.wikipedia.org/wiki/Logarithm)). In our case, this translates to "the logarithm of $p(i)$ to base $1.0001$ is the unique real number $i$ such that $1.0001^i = p(i)$". In formula this is:
 
 $$
 \log_{1.0001}(p(i)) = i

--- a/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
+++ b/uniswap-v3-min-max-tick/uniswap-v3-min-max-tick.md
@@ -18,20 +18,15 @@ $$
 p(i)=1.0001^i
 $$
 
-This relationship can be inverted by taking the base-1.0001 logarithm of both sides.
+This relationship can be inverted by the definition of logarithm: the logarithm of $x$ to base $b$ is the unique real number $y$ such that $b^y = x$ (reference: [Wikipedia](https://en.wikipedia.org/wiki/Logarithm)). In our case, this translates to the logarithm of $p(i)$ to base $1.0001$ is the unique real number $i$ such that $1.0001^i = p(i)$. In formula this is:
 
 $$
-\begin{align*}
-\log_{1.0001}(p(i)) &= \log_{1.0001}(1.0001^i) \\
-\log_{1.0001}(p(i)) &= i
-\end{align*}
+\log_{1.0001}(p(i)) = i
 $$
-
-because $\log_b(b^x)= x$ for any base $b$.
 
 The above formula allows us to calculate the tick index $i$ given the price $p(i)$.
 
-Now, we need to determine the tick index relative to the highest possible token price, which is $2^{128}.$
+Now, we need to determine the tick index relative to the highest possible token price, which is $2^{128}$.
 
 Using  $p(i) = 2^{128}$ in the formula above, we have that
 


### PR DESCRIPTION
We can just use log definition for deriving the formula of calculating i, I think it is more intuitive to do it this way, comparing to using the log identity.